### PR TITLE
Refactor cross-account role assumption

### DIFF
--- a/src/compliance_scanner.py
+++ b/src/compliance_scanner.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError
 
 from utils.exceptions import ComplianceError, AWSServiceError
 from config_manager import ConfigManager
+from utils.helpers import get_ec2_client
 
 class ComplianceScanner:
     """Scans security groups for compliance violations"""
@@ -425,40 +426,20 @@ class ComplianceScanner:
             raise AWSServiceError(f"Failed to describe security groups: {str(e)}")
     
     def _assume_account_role(self, account_id: str) -> None:
-        """Assume cross-account role for scanning"""
+        """Assume cross-account role and initialize the EC2 client."""
         try:
-            # Check if we need to assume a role for this account
-            current_account = self.sts_client.get_caller_identity()['Account']
-            
-            if account_id == current_account:
-                # Same account, use current credentials
-                self.ec2_client = boto3.client('ec2')
-                return
-            
-            # Assume cross-account role
             if not self.cross_account_role_name:
-                raise ComplianceError("Cross-account role name not configured")
-            
-            role_arn = f"arn:aws:iam::{account_id}:role/{self.cross_account_role_name}"
-            
-            response = self.sts_client.assume_role(
-                RoleArn=role_arn,
-                RoleSessionName=f"ComplianceScanner-{account_id}",
-                ExternalId=self.external_id
-            )
-            
-            credentials = response['Credentials']
-            
-            # Create EC2 client with assumed role credentials
-            self.ec2_client = boto3.client(
-                'ec2',
-                aws_access_key_id=credentials['AccessKeyId'],
-                aws_secret_access_key=credentials['SecretAccessKey'],
-                aws_session_token=credentials['SessionToken']
-            )
-            
+                self.ec2_client = get_ec2_client(account_id, 'us-east-1')
+            else:
+                session_name = f"ComplianceScanner-{account_id}"
+                self.ec2_client = get_ec2_client(
+                    account_id,
+                    'us-east-1',
+                    role_name=self.cross_account_role_name,
+                    session_name=session_name,
+                    external_id=self.external_id,
+                )
             self.logger.info(f"Successfully assumed role for account {account_id}")
-            
         except ClientError as e:
             raise ComplianceError(f"Failed to assume role for account {account_id}: {str(e)}")
     


### PR DESCRIPTION
## Summary
- centralize STS role assumption helpers
- use helpers for ComplianceScanner, SecurityGroupRemediator and Lambda handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687198e965648323bcdf0bd1ed9fed15